### PR TITLE
Move 429 to ignore for DCoop check

### DIFF
--- a/linkcheckerrc-dcoop
+++ b/linkcheckerrc-dcoop
@@ -13,6 +13,7 @@ ignore=
   .css$
   .js$
   ^mailto:
+  ^429 Too Many Requests
 
 [output]
 ignoreerrors=
@@ -35,4 +36,3 @@ ignoreerrors=
   ^https://asistdl.onlinelibrary.wiley.com/doi/10.1002/asi.23358 ^403 Forbidden
   ^https://twitter.com ^400 Bad Request
   mission-bg.jpg$ ^404 Not Found
-  .* ^429 Too Many Requests


### PR DESCRIPTION
Were trying to ignore 429 too many requests in the `ignoreerrors` argument, but 429 might not be considered an error. So moving it to the `ignore` argument to see if those will _really_ be ignored.