### PR TITLE
Add vimeo 429 to ignoreerrors

### DIFF
--- a/linkcheckerrc-dcoop
+++ b/linkcheckerrc-dcoop
@@ -36,3 +36,4 @@ ignoreerrors=
   ^https://asistdl.onlinelibrary.wiley.com/doi/10.1002/asi.23358 ^403 Forbidden
   ^https://twitter.com ^400 Bad Request
   mission-bg.jpg$ ^404 Not Found
+  ^https://vimeo.com/* ^429 Too Many Requests


### PR DESCRIPTION
Four vimeo.com URLs keep getting 429 warnings. These are not, technically, errors, but we do not need to hear about them in the report. Trying to ignore those warnings...